### PR TITLE
Refactor change entity mapping

### DIFF
--- a/src/main/java/com/fighting/weatherdress/post/dto/PostResponse.java
+++ b/src/main/java/com/fighting/weatherdress/post/dto/PostResponse.java
@@ -31,7 +31,7 @@ public class PostResponse {
 
   private final List<String> imageUrls;
 
-  public static PostResponse fromEntity(Post post) {
+  public static PostResponse fromEntity(Post post, List<Image> images) {
     return PostResponse.builder()
         .id(post.getId())
         .text(post.getText())
@@ -43,7 +43,7 @@ public class PostResponse {
             .sido(post.getLocation().getSido())
             .sigungu(post.getLocation().getSigungu())
             .build())
-        .imageUrls(getImages(post.getImages()))
+        .imageUrls(getImages(images))
         .build();
   }
 

--- a/src/main/java/com/fighting/weatherdress/post/entity/Image.java
+++ b/src/main/java/com/fighting/weatherdress/post/entity/Image.java
@@ -36,11 +36,9 @@ public class Image extends BaseEntity {
   private Post post;
 
   public static Image toEntity(String url, Post post) {
-    Image image = Image.builder()
+    return Image.builder()
         .url(url)
         .post(post)
         .build();
-    post.getImages().add(image);
-    return image;
   }
 }

--- a/src/main/java/com/fighting/weatherdress/post/entity/Post.java
+++ b/src/main/java/com/fighting/weatherdress/post/entity/Post.java
@@ -54,10 +54,6 @@ public class Post extends BaseEntity {
   @JoinColumn(name = "location_id")
   private Location location;
 
-  @Builder.Default
-  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Image> images = new ArrayList<>();
-
   public static Post toEntity(String text, ShortTermWeatherResponse weather,
       Member member,
       Location location) {

--- a/src/test/java/com/fighting/weatherdress/post/service/PostServiceTest.java
+++ b/src/test/java/com/fighting/weatherdress/post/service/PostServiceTest.java
@@ -334,9 +334,9 @@ class PostServiceTest {
             .sido("경기")
             .sigungu("군포시")
             .build())
-        .images(images)
         .build();
     given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+    given(imageRepository.findAllByPost(post)).willReturn(images);
     //when
     PostResponse response = postService.getPost(1L);
     //then
@@ -350,8 +350,8 @@ class PostServiceTest {
     assertEquals(post.getMember().getNickName(), response.getMember().getNickName());
     assertEquals(post.getLocation().getSido(), response.getLocation().getSido());
     assertEquals(post.getLocation().getSigungu(), response.getLocation().getSigungu());
-    assertEquals(post.getImages().size(), response.getImageUrls().size());
-    assertEquals(post.getImages().get(0).getUrl(), response.getImageUrls().get(0));
+    assertEquals(images.size(), response.getImageUrls().size());
+    assertEquals(images.get(0).getUrl(), response.getImageUrls().get(0));
   }
 
   @Test
@@ -386,11 +386,11 @@ class PostServiceTest {
             .sido("경기")
             .sigungu("군포시")
             .build())
-        .images(images)
         .build();
     List<Post> postList = List.of(post);
     Page<Post> result = new PageImpl<>(postList);
     given(postRepository.findAll(any(Pageable.class))).willReturn(result);
+    given(imageRepository.findAllByPost(post)).willReturn(images);
 
     // when
     PageRequest pageRequest = PageRequest.of(0, 10, Direction.DESC, "createdAt");
@@ -416,9 +416,9 @@ class PostServiceTest {
     assertEquals(responseSlice.getContent().get(0).getLocation().getSigungu(),
         post.getLocation().getSigungu());
     assertEquals(responseSlice.getContent().get(0).getImageUrls().size(),
-        post.getImages().size());
+        images.size());
     assertEquals(responseSlice.getContent().get(0).getImageUrls().get(0),
-        post.getImages().get(0).getUrl());
+        images.get(0).getUrl());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- Post(OneToMany) 와 Image(ManyToOne) 양방향 관계를 Image(ManyToOne) 단방향 관계로 변경
  - 변경사유 : 양방향 관계 설정으로 인한 양쪽 객체를 관리할 경우 관리포인트가 단일화되지 않아 의도치 않은 실수 발생이 우려됨.(ex. 부모객체에서 자식 객체를 관리하는 경우 삭제가 되지 않는 것과 같은 경우 발생 가능성 있음)
  - 참고 : https://kobumddaring.tistory.com/70
  - 부득이한 경우가 아니라면 ManyToOne 단방향 관계를 사용하는 것이 관리포인트가 단일화되는 장점이 있음.
  - OneToMany 단방향 관계는 의도치 않은 쿼리가 발생할 수 있으므로, ManyToOne 단방향 > OneToMany 양방향 > OneToMany 단방향이 바람직 할 것으로 보임.

**TO-BE**
- 답글 조회 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 