### PR TITLE
Register like

### DIFF
--- a/src/main/java/com/fighting/weatherdress/global/type/ErrorCode.java
+++ b/src/main/java/com/fighting/weatherdress/global/type/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(NOT_FOUND, "가입한 멤버가 존재하지 않습니다."),
   POST_NOT_FOUND(NOT_FOUND, "작성된 게시글이 존재하지 않습니다."),
   MEMBER_IS_NOT_WRITER(FORBIDDEN, "작성자가 아닙니다."),
-  NOT_FOUND_REPLY(NOT_FOUND, "해당 답글이 존재하지 않습니다.")
+  NOT_FOUND_REPLY(NOT_FOUND, "해당 답글이 존재하지 않습니다."),
+  INVALID_LIKE_REQUEST(BAD_REQUEST, "게시글과 답글 중 하나만 좋아요 등록 요청해야 합니다.")
 
   ;
 

--- a/src/main/java/com/fighting/weatherdress/like/controller/LikeController.java
+++ b/src/main/java/com/fighting/weatherdress/like/controller/LikeController.java
@@ -1,0 +1,26 @@
+package com.fighting.weatherdress.like.controller;
+
+import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
+import com.fighting.weatherdress.like.service.LikeService;
+import com.fighting.weatherdress.security.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/like")
+public class LikeController {
+
+  private final LikeService likeService;
+
+  @PostMapping
+  public void registerLike(@RequestBody LikeRegisterRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    likeService.registerLike(request, userDetails.getId());
+  }
+
+}

--- a/src/main/java/com/fighting/weatherdress/like/dto/LikeRegisterRequest.java
+++ b/src/main/java/com/fighting/weatherdress/like/dto/LikeRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.fighting.weatherdress.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LikeRegisterRequest {
+
+  private Long postId;
+
+  private Long replyId;
+
+}

--- a/src/main/java/com/fighting/weatherdress/like/dto/LikeRegisterRequest.java
+++ b/src/main/java/com/fighting/weatherdress/like/dto/LikeRegisterRequest.java
@@ -2,11 +2,13 @@ package com.fighting.weatherdress.like.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode
 public class LikeRegisterRequest {
 
   private Long postId;

--- a/src/main/java/com/fighting/weatherdress/like/entity/Like.java
+++ b/src/main/java/com/fighting/weatherdress/like/entity/Like.java
@@ -1,0 +1,43 @@
+package com.fighting.weatherdress.like.entity;
+
+import com.fighting.weatherdress.global.entity.BaseEntity;
+import com.fighting.weatherdress.member.domain.Member;
+import com.fighting.weatherdress.post.entity.Post;
+import com.fighting.weatherdress.reply.entity.Reply;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class Like extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private Post post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reply_id")
+  private Reply reply;
+}

--- a/src/main/java/com/fighting/weatherdress/like/entity/Like.java
+++ b/src/main/java/com/fighting/weatherdress/like/entity/Like.java
@@ -1,6 +1,8 @@
 package com.fighting.weatherdress.like.entity;
 
 import com.fighting.weatherdress.global.entity.BaseEntity;
+import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
+import com.fighting.weatherdress.like.etc.LikeTarget;
 import com.fighting.weatherdress.member.domain.Member;
 import com.fighting.weatherdress.post.entity.Post;
 import com.fighting.weatherdress.reply.entity.Reply;
@@ -11,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +34,7 @@ public class Like extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
+  @NotNull
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -40,4 +44,21 @@ public class Like extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "reply_id")
   private Reply reply;
+
+  public static Like toEntity(LikeTarget likeTarget, Member member, boolean isLikeForPost) {
+    Like like;
+    if (isLikeForPost) {
+      like = Like.builder()
+          .member(member)
+          .post((Post) likeTarget)
+          .build();
+    } else {
+      like = Like.builder()
+          .member(member)
+          .reply((Reply) likeTarget)
+          .build();
+    }
+    return like;
+  }
+
 }

--- a/src/main/java/com/fighting/weatherdress/like/entity/Like.java
+++ b/src/main/java/com/fighting/weatherdress/like/entity/Like.java
@@ -1,7 +1,6 @@
 package com.fighting.weatherdress.like.entity;
 
 import com.fighting.weatherdress.global.entity.BaseEntity;
-import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
 import com.fighting.weatherdress.like.etc.LikeTarget;
 import com.fighting.weatherdress.member.domain.Member;
 import com.fighting.weatherdress.post.entity.Post;
@@ -13,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +26,7 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
+@Table(name = "`like`")
 public class Like extends BaseEntity {
 
   @Id

--- a/src/main/java/com/fighting/weatherdress/like/etc/LikeTarget.java
+++ b/src/main/java/com/fighting/weatherdress/like/etc/LikeTarget.java
@@ -1,0 +1,5 @@
+package com.fighting.weatherdress.like.etc;
+
+public interface LikeTarget {
+
+}

--- a/src/main/java/com/fighting/weatherdress/like/repository/LikeRepository.java
+++ b/src/main/java/com/fighting/weatherdress/like/repository/LikeRepository.java
@@ -1,0 +1,10 @@
+package com.fighting.weatherdress.like.repository;
+
+import com.fighting.weatherdress.like.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+}

--- a/src/main/java/com/fighting/weatherdress/like/service/LikeService.java
+++ b/src/main/java/com/fighting/weatherdress/like/service/LikeService.java
@@ -1,0 +1,63 @@
+package com.fighting.weatherdress.like.service;
+
+import static com.fighting.weatherdress.global.type.ErrorCode.INVALID_LIKE_REQUEST;
+import static com.fighting.weatherdress.global.type.ErrorCode.MEMBER_NOT_FOUND;
+import static com.fighting.weatherdress.global.type.ErrorCode.NOT_FOUND_REPLY;
+import static com.fighting.weatherdress.global.type.ErrorCode.POST_NOT_FOUND;
+
+import com.fighting.weatherdress.global.exception.CustomException;
+import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
+import com.fighting.weatherdress.like.entity.Like;
+import com.fighting.weatherdress.like.etc.LikeTarget;
+import com.fighting.weatherdress.like.repository.LikeRepository;
+import com.fighting.weatherdress.member.domain.Member;
+import com.fighting.weatherdress.member.repository.MemberRepository;
+import com.fighting.weatherdress.post.repository.PostRepository;
+import com.fighting.weatherdress.reply.repository.ReplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+  private final LikeRepository likeRepository;
+  private final PostRepository postRepository;
+  private final ReplyRepository replyRepository;
+  private final MemberRepository memberRepository;
+
+  public void registerLike(LikeRegisterRequest request, long memberId) {
+    boolean isLikeForPost = checkLikeForPost(request);
+
+    LikeTarget likeTarget = getLikeTarget(request, isLikeForPost);
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    likeRepository.save(Like.toEntity(likeTarget, member, isLikeForPost));
+  }
+
+  private boolean checkLikeForPost(LikeRegisterRequest request) {
+    if (request.getPostId() != null && request.getReplyId() == null) {
+      return true;
+    } else if (request.getReplyId() != null && request.getPostId() == null) {
+      return false;
+    } else {
+      throw new CustomException(INVALID_LIKE_REQUEST);
+    }
+  }
+
+  private LikeTarget getLikeTarget(LikeRegisterRequest request, boolean isLikeForPost) {
+    LikeTarget likeTarget;
+    if (isLikeForPost) {
+      likeTarget = postRepository.findById(request.getPostId())
+          .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    } else {
+      likeTarget = replyRepository.findById(request.getReplyId())
+          .orElseThrow(() -> new CustomException(NOT_FOUND_REPLY));
+    }
+    return likeTarget;
+  }
+
+
+}

--- a/src/main/java/com/fighting/weatherdress/post/entity/Post.java
+++ b/src/main/java/com/fighting/weatherdress/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.fighting.weatherdress.post.entity;
 
 import com.fighting.weatherdress.global.entity.BaseEntity;
 import com.fighting.weatherdress.global.entity.Location;
+import com.fighting.weatherdress.like.etc.LikeTarget;
 import com.fighting.weatherdress.member.domain.Member;
 import com.fighting.weatherdress.weather.dto.ShortTermWeatherResponse;
 import jakarta.persistence.CascadeType;
@@ -28,7 +29,7 @@ import org.hibernate.envers.AuditOverride;
 @Builder
 @Entity
 @AuditOverride(forClass = BaseEntity.class)
-public class Post extends BaseEntity {
+public class Post extends BaseEntity implements LikeTarget {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fighting/weatherdress/reply/entity/Reply.java
+++ b/src/main/java/com/fighting/weatherdress/reply/entity/Reply.java
@@ -1,6 +1,7 @@
 package com.fighting.weatherdress.reply.entity;
 
 import com.fighting.weatherdress.global.entity.BaseEntity;
+import com.fighting.weatherdress.like.etc.LikeTarget;
 import com.fighting.weatherdress.member.domain.Member;
 import com.fighting.weatherdress.post.entity.Post;
 import jakarta.persistence.Entity;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
-public class Reply extends BaseEntity {
+public class Reply extends BaseEntity implements LikeTarget {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/fighting/weatherdress/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/fighting/weatherdress/like/controller/LikeControllerTest.java
@@ -1,0 +1,51 @@
+package com.fighting.weatherdress.like.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fighting.weatherdress.config.WithMockCustomUser;
+import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
+import com.fighting.weatherdress.like.service.LikeService;
+import com.fighting.weatherdress.security.filter.JwtAuthenticationFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = LikeController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)})
+class LikeControllerTest {
+
+  @MockBean
+  private LikeService likeService;
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithMockCustomUser
+  void successRegisterLike() throws Exception {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .postId(1L)
+        .build();
+    //when
+    mockMvc.perform(post("/like")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request))
+        .with(csrf()))
+        .andDo(print())
+        .andExpect(status().isOk());
+    //then
+    verify(likeService).registerLike(request, 1L);
+  }
+}

--- a/src/test/java/com/fighting/weatherdress/like/service/LikeServiceTest.java
+++ b/src/test/java/com/fighting/weatherdress/like/service/LikeServiceTest.java
@@ -1,0 +1,158 @@
+package com.fighting.weatherdress.like.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fighting.weatherdress.global.exception.CustomException;
+import com.fighting.weatherdress.global.type.ErrorCode;
+import com.fighting.weatherdress.like.dto.LikeRegisterRequest;
+import com.fighting.weatherdress.like.entity.Like;
+import com.fighting.weatherdress.like.repository.LikeRepository;
+import com.fighting.weatherdress.member.domain.Member;
+import com.fighting.weatherdress.member.repository.MemberRepository;
+import com.fighting.weatherdress.post.entity.Post;
+import com.fighting.weatherdress.post.repository.PostRepository;
+import com.fighting.weatherdress.reply.entity.Reply;
+import com.fighting.weatherdress.reply.repository.ReplyRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+  @Mock
+  private LikeRepository likeRepository;
+  @Mock
+  private PostRepository postRepository;
+  @Mock
+  private ReplyRepository replyRepository;
+  @Mock
+  private MemberRepository memberRepository;
+  @InjectMocks
+  private LikeService likeService;
+
+  @Test
+  void successRegisterLikeForPost() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .postId(13L)
+        .build();
+    Post post = mock(Post.class);
+    Member member = mock(Member.class);
+    given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+    given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+    //when
+    likeService.registerLike(request, 133L);
+    //then
+    ArgumentCaptor<Like> argumentCaptor = ArgumentCaptor.forClass(Like.class);
+
+    verify(likeRepository).save(argumentCaptor.capture());
+
+    assertEquals(member, argumentCaptor.getValue().getMember());
+    assertEquals(post, argumentCaptor.getValue().getPost());
+  }
+
+  @Test
+  void successRegisterLikeForReply() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .replyId(13L)
+        .build();
+    Reply reply = mock(Reply.class);
+    Member member = mock(Member.class);
+
+    given(replyRepository.findById(anyLong())).willReturn(Optional.of(reply));
+    given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+    //when
+    likeService.registerLike(request, 133L);
+    //then
+    ArgumentCaptor<Like> argumentCaptor = ArgumentCaptor.forClass(Like.class);
+
+    verify(likeRepository).save(argumentCaptor.capture());
+
+    assertEquals(member, argumentCaptor.getValue().getMember());
+    assertEquals(reply, argumentCaptor.getValue().getReply());
+  }
+
+  @Test
+  void registerLike_throwInvalidLikeRequest_whenBothPostAndReplyIsNull() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder().build();
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> likeService.registerLike(request, 133L));
+    //then
+    assertEquals(customException.getErrorCode(), ErrorCode.INVALID_LIKE_REQUEST);
+  }
+
+  @Test
+  void registerLike_throwInvalidLikeRequest_whenBothPostAndReplyIsNotNull() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .postId(123L)
+        .replyId(1234L)
+        .build();
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> likeService.registerLike(request, 133L));
+    //then
+    assertEquals(customException.getErrorCode(), ErrorCode.INVALID_LIKE_REQUEST);
+  }
+
+  @Test
+  void registerLike_throwPostNotFound_whenPostIdIsNotExist() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .postId(13L)
+        .build();
+
+    given(postRepository.findById(anyLong())).willReturn(Optional.empty());
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> likeService.registerLike(request, 133L));
+    //then
+    assertEquals(customException.getErrorCode(), ErrorCode.POST_NOT_FOUND);
+  }
+
+  @Test
+  void registerLike_throwNotFoundReply_whenReplyIdIsNotExist() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .replyId(13L)
+        .build();
+
+    given(replyRepository.findById(anyLong())).willReturn(Optional.empty());
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> likeService.registerLike(request, 133L));
+    //then
+    assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_REPLY);
+  }
+
+  @Test
+  void registerLike_throwMemberNotFound_whenMemberIdIsNotExist() {
+    //given
+    LikeRegisterRequest request = LikeRegisterRequest.builder()
+        .postId(13L)
+        .build();
+    Post post = mock(Post.class);
+
+    given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+    given(memberRepository.findById(anyLong())).willReturn(Optional.empty());
+    //when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> likeService.registerLike(request, 133L));
+    //then
+    assertEquals(customException.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND);
+  }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 좋아요 등록 기능 구현
  - LikeRegisterRequest를 통해 replyId 또는 postId를 입력받습니다.
  - LikeRegisterRequest에서 replyId 와 postId를 동시에 입력하거나, 동시에 값이 null인 경우 예외 발생 처리하였습니다.
  - LikeTarget 인터페이스를 새로 만듬과 동시에, Reply, Post 엔티티가 LikeTarget을 상속받도록 하여 향후 좋아요 기능이 확장될 수 있도록 하였습니다.
  - 현재는 Post, Reply에만 좋아요 기능이 적용되기 때문에, boolean으로 Post의 좋아요인지 구분하여 사용합니다.(향후 좋아요 기능이 적용될 범위가 넓어지면 boolean 대신 enum을 사용하여 관리하는 것이 좋을 것으로 보입니다.)
  - 로그인한 회원만 좋아요 기능을 사용할 수 있도록 @AuthenticationPrincipal을 사용하였습니다.
 
**TO-BE**
- 좋아요 취소 기능 구현
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 