### PR TITLE
refactor: 중기날씨예보 조회 엔티티 구조 변경

### DIFF
--- a/src/main/java/com/fighting/weatherdress/global/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/fighting/weatherdress/global/config/RestTemplateConfiguration.java
@@ -13,7 +13,7 @@ public class RestTemplateConfiguration {
     RestTemplate restTemplate = new RestTemplate();
     SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
     requestFactory.setConnectTimeout(5 * 60 * 1000);
-    requestFactory.setReadTimeout(10 * 1000);
+    requestFactory.setReadTimeout(5 * 60 * 1000);
 
     restTemplate.setRequestFactory(requestFactory);
 

--- a/src/main/java/com/fighting/weatherdress/global/entity/Location.java
+++ b/src/main/java/com/fighting/weatherdress/global/entity/Location.java
@@ -49,10 +49,6 @@ public class Location extends BaseEntity{
 
   @Builder.Default
   @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<WeeklyWeather> weeklyWeathers = new ArrayList<>();
-
-  @Builder.Default
-  @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Post> posts = new ArrayList<>();
 
 }

--- a/src/main/java/com/fighting/weatherdress/weather/entity/WeeklyWeather.java
+++ b/src/main/java/com/fighting/weatherdress/weather/entity/WeeklyWeather.java
@@ -1,5 +1,6 @@
 package com.fighting.weatherdress.weather.entity;
 
+import com.fighting.weatherdress.global.entity.BaseEntity;
 import com.fighting.weatherdress.global.entity.Location;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.envers.AuditOverride;
 
 @Getter
 @Setter
@@ -22,7 +24,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Entity
-public class WeeklyWeather {
+@AuditOverride(forClass = BaseEntity.class)
+public class WeeklyWeather extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fighting/weatherdress/weather/repository/WeeklyWeatherRepository.java
+++ b/src/main/java/com/fighting/weatherdress/weather/repository/WeeklyWeatherRepository.java
@@ -1,10 +1,14 @@
 package com.fighting.weatherdress.weather.repository;
 
+import com.fighting.weatherdress.global.entity.Location;
 import com.fighting.weatherdress.weather.entity.WeeklyWeather;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WeeklyWeatherRepository extends JpaRepository<WeeklyWeather, Long> {
-
+  void deleteAllByCreatedAtBefore(LocalDateTime date);
+  List<WeeklyWeather> findAllByLocation(Location location);
 }

--- a/src/main/java/com/fighting/weatherdress/weather/service/LongTermWeatherService.java
+++ b/src/main/java/com/fighting/weatherdress/weather/service/LongTermWeatherService.java
@@ -51,7 +51,7 @@ public class LongTermWeatherService {
         .sido(location.getSido())
         .sigungu(location.getSigungu())
         .weeklyWeathers(
-            location.getWeeklyWeathers()
+            weeklyWeatherRepository.findAllByLocation(location)
                 .stream()
                 .map(WeeklyWeatherDto::fromEntity)
                 .sorted((Comparator.comparing(WeeklyWeatherDto::getDate)))
@@ -73,8 +73,6 @@ public class LongTermWeatherService {
           location.getLocationLandCode());
       WeeklyTemperatureItem temperature = getWeeklyTemperatureFromApi(now,
           location.getLocationCode());
-
-      location.getWeeklyWeathers().clear();
 
       for (int i = 2; i <= 6; i++) {
         String minTemperature = "minTemperaturePlus" + i + "Days";
@@ -98,6 +96,8 @@ public class LongTermWeatherService {
         weeklyWeatherRepository.save(weeklyWeather);
       }
     }
+
+    weeklyWeatherRepository.deleteAllByCreatedAtBefore(now);
   }
 
   private Field getField(Class<?> inputClass, String fieldName)
@@ -111,7 +111,8 @@ public class LongTermWeatherService {
       String locationLandCode) throws URISyntaxException {
     URI uri = makeWeeklyForecastUri(locationLandCode, now);
 
-    ResponseEntity<ResponseFromWeeklyForecastApi> responseEntity = restTemplate.getForEntity(uri,
+    ResponseEntity<ResponseFromWeeklyForecastApi> responseEntity = restTemplate.getForEntity(
+        uri,
         ResponseFromWeeklyForecastApi.class);
     ResponseFromWeeklyForecastApi response = responseEntity.getBody();
 
@@ -137,7 +138,8 @@ public class LongTermWeatherService {
       String locationCode) throws URISyntaxException {
     URI uri = makeWeeklyTemperatureUri(locationCode, now);
 
-    ResponseEntity<ResponseFromWeeklyTemperatureApi> responseEntity = restTemplate.getForEntity(uri,
+    ResponseEntity<ResponseFromWeeklyTemperatureApi> responseEntity = restTemplate.getForEntity(
+        uri,
         ResponseFromWeeklyTemperatureApi.class);
     ResponseFromWeeklyTemperatureApi response = responseEntity.getBody();
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존 Location 엔티티와 WeeklyWeather 엔티티 양방향 관계설정을 ManyToOne 단방향 관계 설정으로 변경
  - 변경사유 : 양방향 관계로 양쪽 객체를 관리하는 것보다 단방향으로 하나의 객체만 관리하는 것이 관리포인트가 줄어들어 추후 문제발생 가능성 축소될 것으로 보임.(엔티티 관계가 변경됨에 따른 기능 및 성능에 큰 변화 없음)

- WeeklyWeatehr 엔티티에 createdAt, modifiedAt 필드 추가
  - 엔티티 관리하여 추후 쓸모없는 오래된 데이터 삭제하기 용이함

- 중기 날씨 업데이트 메서드 로직 변경
  - 기존 : 저장된 데이터를 먼저 삭제 후 외부 API로부터 신규 데이터를 받아 와 DB에 기록함.
  - 변경 : 외부 API로부터 신규 데이터 DB에 저장 후 예전 데이터 일괄 삭제
  - 변경사유 : 기존 방식도 트랜잭션으로 관리하고 있기 때문에 메서드 실행 중 문제 발생 시 롤백될 가능성 높으나, 트랜잭션 관리에 실패할 경우에도 기존 데이터를 먼저 삭제하는 것보다 신규 데이터를 기록 후 기존 데이터를 삭제하는 것이 안정적일 것으로 판단함.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 